### PR TITLE
add process.env.USERPROFILE option to default working dir for windows machines

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,7 +24,7 @@ module.exports =
     workingDir:
       type        : 'string'
       description : 'Working Directory'
-      default     : path.join(process.env.HOME, OmnibloxPart.defaultConfig().darwin['workingDir'] .slice(1))
+      default     : path.join(process.env.HOME || process.env.USERPROFILE, OmnibloxPart.defaultConfig().darwin['workingDir'].slice(1))
     externalTools:
       type: 'object'
       properties:


### PR DESCRIPTION
Hey there, nice atom package! I booted this up on my home computer (Windows) and was hit with this error:

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.join (path.js:466:7)
    at /packages/maker-ide-atom/lib/main.coffee:27:26)
    at /packages/maker-ide-atom/lib/main.coffee:1:1)
    at Module._compile (/app.asar/src/native-compile-cache.js:109:30)
    at /app.asar/src/compile-cache.js:216:21)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (/app.asar/src/native-compile-cache.js:50:27)
    at Package.module.exports.Package.requireMainModule (/app.asar/src/package.js:796:27)
    at /app.asar/src/package.js:123:28
    at Package.module.exports.Package.measure (/app.asar/src/package.js:96:15)
    at Package.module.exports.Package.load (/app.asar/src/package.js:110:12)
    at PackageManager.module.exports.PackageManager.loadPackage (/app.asar/src/package-manager.js:468:14)
    at PackageManager.module.exports.PackageManager.activatePackage (/app.asar/src/package-manager.js:548:30)
    at /app.asar/node_modules/settings-view/lib/package-manager.js:484:29
    at exit (/app.asar/node_modules/settings-view/lib/package-manager.js:99:16)
    at triggerExitCallback (/app.asar/src/buffered-process.js:322:11)
    at /app.asar/src/buffered-process.js:352:11)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
```

[looking into it](http://stackoverflow.com/questions/9080085/node-js-find-home-directory-in-platform-agnostic-way), it seems that `process.env.HOME` is not used on windows machines, but `process.env.USERPROFILE` is, meaning that when main.coffee tries to parse the default CWD it sends `undefined` as the first string to `path.join` on windows. ORing them together works so I thought I'd throw up a PR, but there are probably better ways to do it. Thanks!