### PR TITLE
hash basename in sceneID to avoid query selector problems

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,11 +1,19 @@
 path = require 'path'
 url  = require 'url'
-hash = require 'string-hash'
 _ = require 'underscore-plus'
 SingleFile = require './single-file'
 EditorPreviewView = require './editor-preview-view'
 {CompositeDisposable, Disposable, Emitter} = require 'atom'
 {OmnibloxView, OmnibloxPart, OmnibloxCompositor, OmnibloxFabricator} = require '@omniblox/omniblox-common'
+
+# string-hash
+hash = (str) ->
+  hashNum = 5381
+  i = str.length
+
+  while(i)
+    hashNum = (hashNum * 33) ^ str.charCodeAt(--i)
+  hashNum >>> 0;
 
 # Mouse tracking In Editor
 # closestTextEditor = (target) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 url  = require 'url'
+hash = require 'string-hash'
 _ = require 'underscore-plus'
 SingleFile = require './single-file'
 EditorPreviewView = require './editor-preview-view'
@@ -143,7 +144,7 @@ openURI = (uriToOpen) ->
   catch error
     return
 
-  sceneID = "#{Date.now()}-#{path.basename(uriToOpen, path.extname(uriToOpen))}"
+  sceneID = "#{Date.now()}-#{hash(path.basename(uriToOpen, path.extname(uriToOpen)))}"
 
   if protocol is 'maker-ide-atom:'
     openEditorPreview(uriToOpen, host, pathname, sceneID)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@omniblox/omniblox-common": "^0.5.0",
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
-    "string-hash": "^1.1.3",
     "underscore-plus": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@omniblox/omniblox-common": "^0.5.0",
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
+    "string-hash": "^1.1.3",
     "underscore-plus": "^1.0.0"
   }
 }


### PR DESCRIPTION
Hey there, me again! Let me know if these are bothersome, I'm just chucking PRs up for whatever bugs I find.

As for this one, I named a file 'foo.scad.stl' since it was being generated from an automated build process and got an error on adding the factory button and then trying to reference it to add the event listener. I did some digging and found that certain characters need to be escaped if you're going to use them as an ID for an html element and then later reference them via a query selector. In lieu of implementing [this massive regex](http://stackoverflow.com/questions/2786538/need-to-escape-a-special-character-in-a-jquery-selector-string) every time you want to use the sceneID in a query selector I figured you could just hash the basename in the sceneID instead.

lemme know if this PR needs anything else!

~Bob